### PR TITLE
StePS: Added CPU-only octree and randomized octree force calculation

### DIFF
--- a/StePS/CHANGELOG.md
+++ b/StePS/CHANGELOG.md
@@ -1,17 +1,23 @@
 # Change Log
-All notable changes to the StePS simulation code will be documented in this file.
+All notable changes to the StePS simulation code is documented in this file.
 
 ## [TBD] - TBD
 
 ### Added
+- Barnes-Hut (Octree) force calculation option (CPU only) [J. Barnes, P. Hut Nature 324 (6096) (1986) 446–449.]
+- Random domain center shift option for periodic Barnes-Hut simulations
+- Random domain center shift and rotation option for non-periodic Barnes-Hut simulations
+- Random domain center shift and rotation in cylindrical Barnes-Hut simulations
 - Cylindrically symmetric boundary conditions
 
 ### Changed
 - Updated makefile templates
+- w0 and wa parameter values of wCDM and w0waCDM cosmologies are saved into the hdf5 snapshots
 
 ### Fixed
-- Fixed constant-resolution periodic initial condition reading from HDF5 format.
+- Fixed constant-resolution periodic initial condition reading from HDF5 format
 - Fixed H0 independent unit bugs
+- Fixed high-accuracy Ewald summation option in fully periodic simulations 
 
 ## [v1.0.2.2] - 2024-10-25
 

--- a/StePS/README.txt
+++ b/StePS/README.txt
@@ -7,12 +7,21 @@
 
 StePS - STEreographically Projected cosmological Simulations
 
-v1.0.2.2
-Copyright (C) 2017-2024 Gábor Rácz
+v1.3.0.0
+Copyright (C) 2017-2025 Gábor Rácz - gabor.racz@helsinki.fi
+  Department of Physics, University of Helsinki | Gustaf Hällströmin katu 2, Helsinki, Finland
   Jet Propulsion Laboratory, California Institute of Technology | 4800 Oak Grove Drive, Pasadena, CA, 91109, USA
   Department of Physics of Complex Systems, Eotvos Lorand University | Pf. 32, H-1518 Budapest, Hungary
   Department of Physics & Astronomy, Johns Hopkins University | 3400 N. Charles Street, Baltimore, MD 21218
-gabor.racz@jpl.nasa.gov
+
+Contributors:
+  2025 Viola Varga - viola.varga@helsinki.fi
+    Department of Physics, University of Helsinki | Gustaf Hällströmin katu 2, Helsinki, Finland 
+  2025 Balázs Pál - pal.balazs@ttk.elte.hu
+    Department of Physics of Complex Systems, Eotvos Lorand University | Pf. 32, H-1518 Budapest, Hungary
+    Institute for Particle and Nuclear Physics, HUN-REN Wigner Research Centre for Physics | Pf. 49, H-1525 Budapest, Hungary.
+
+
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -24,13 +33,14 @@ gabor.racz@jpl.nasa.gov
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-A direct N-body code for compactified cosmological simulations.
+An N-body code for compactified cosmological simulations.
 
 Main features:
 - Optimized to run dark matter only N-body simulations in LambdaCDM, wCDM or w0waCDM cosmology.
-- Running simulations with different models are possible by using external tabulated expansion histories.
-- Able to run standard periodic and non-periodic spherical cosmological simulations.
-- Can be used to make periodic, quasi-periodic or spherical glass.
+- Running simulations with other models are possible by using external tabulated expansion histories.
+- Able to run standard periodic, cylindrical, and non-periodic spherical cosmological simulations.
+- Direct [CPU & GPU], Octree (a.k.a. Barnes-Hut)[CPU only], and randomized Octree [CPU only] force calculation.
+- Can be used to make periodic, quasi-periodic, cylindrical or spherical glass.
 - Available for GNU/Linux and Darwin (macOS).
 - Written in C++ with MPI, OpenMP and CUDA parallelization.
 - Able to use multiple GPUs simultaneously in a large computing cluster.
@@ -177,7 +187,7 @@ a_max           1.0				%The final scalefactor (if COMOVING_INTEGRATION=1) or the
 Simulation parameters:
 -----------------------
 COSMOLOGY       1			%1=cosmological simulation 0=traditional n-body sim.
-IS_PERIODIC     0						%Boundary condition 0=none, 1=nearest images, 2=Ewald forces, 3=high precision Ewald forces
+IS_PERIODIC     0						%Boundary condition 0=vacuum boundaries, 1=nearest images (a.k.a. quasi-periodic), 2=Ewald forces, 3>=high precision Ewald forces
 COMOVING_INTEGRATION    1					%Comoving integration 0=no, 1=yes, used only when  COSMOLOGY=1
 L_BOX           1860.0531					%Linear size of the simulation volume
 IC_FILE 	./examples/ic/IC_LCDM_SP_1860Mpc_Nr224_Nhp32_ds105_z63_VOI100_notcomoving.hdf5	%ic file
@@ -214,3 +224,4 @@ Acknowledgement
   GR would like to thank the Department of Physics & Astronomy, JHU for supporting this work.
   GR acknowledges sponsorship of a NASA Postdoctoral Program Fellowship. GR was supported by JPL, which is run under contract by California Institute of Technology for NASA.
   The developer acknowledges support from the National Science Foundation (NSF) award 1616974.
+  GR acknowledges the support of the Research Council of Finland grant 354905 and the support by the European Research Council via ERC Consolidator grant KETJU (no. 818930).

--- a/StePS/Template-Darwin-Makefile
+++ b/StePS/Template-Darwin-Makefile
@@ -1,12 +1,12 @@
 
 #-----------------------------------------------------------------------------------------------#
 # StePS Makefile
-# Copyright (C) 2017-2025 Gabor Racz et al.
+# Copyright (C) 2017-2025 Gabor Racz
 #		Department of Physics, University of Helsinki | Helsinki, Finland
-#	Jet Propulsion Laboratory, California Institute of Technology | Pasadena, CA, USA
-# 	Department of Physics of Complex Systems, Eotvos Lorand University | Budapest, Hungary
-# 	Department of Physics & Astronomy, Johns Hopkins University | Baltimore, MD, USA
-VERSION='"v1.0.3.2-dev"'
+#		Jet Propulsion Laboratory, California Institute of Technology | Pasadena, CA, USA
+# 		Department of Physics of Complex Systems, Eotvos Lorand University | Budapest, Hungary
+# 		Department of Physics & Astronomy, Johns Hopkins University | Baltimore, MD, USA
+VERSION='"v1.3.0.0-dev"'
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
@@ -22,14 +22,18 @@ VERSION='"v1.0.3.2-dev"'
 #------------------------------- Precision option for the force calculation
 #OPT += -DUSE_SINGLE_PRECISION
 
+#------------------------------- Options for the force calculation method (if everthing is commented out, direct summation is used)
+#OPT += -DUSE_BH=0.25 # Use the Barnes-Hut (OctTree) method for force calculation with an opening angle of 0.25. (Recommended value is 0.25)
+#OPT += -DRANDOMIZE_BH=123456 # Randomize the BH tree to avoid artifacts. Only works with the BH method, and it is highly recommended to use it.
+
 #------------------------------- Options for boundary conditions (only uncomment one of them)
 #OPT += -DPERIODIC # Periodic boundary conditions
 #OPT += -DPERIODIC_Z # Periodic boundary conditions in the z-direction only
 
-#------------------------------- Option of HDF5
+#------------------------------- Option for enabling HDF5 I/O
 OPT += -DHAVE_HDF5
 
-#------------------------------- Glass making option
+#------------------------------- Option for turning on glass making mode
 #OPT += -DGLASS_MAKING
 
 #------------------------------- Parametrization of the background cosmology

--- a/StePS/Template-LinuxGCC-Makefile
+++ b/StePS/Template-LinuxGCC-Makefile
@@ -1,12 +1,12 @@
 
 #-----------------------------------------------------------------------------------------------#
 # StePS Makefile
-# Copyright (C) 2017-2025 Gabor Racz et al.
+# Copyright (C) 2017-2025 Gabor Racz
 #		Department of Physics, University of Helsinki | Helsinki, Finland
-#	Jet Propulsion Laboratory, California Institute of Technology | Pasadena, CA, USA
-# 	Department of Physics of Complex Systems, Eotvos Lorand University | Budapest, Hungary
-# 	Department of Physics & Astronomy, Johns Hopkins University | Baltimore, MD, USA
-VERSION='"v1.0.3.2-dev"'
+#		Jet Propulsion Laboratory, California Institute of Technology | Pasadena, CA, USA
+# 		Department of Physics of Complex Systems, Eotvos Lorand University | Budapest, Hungary
+# 		Department of Physics & Astronomy, Johns Hopkins University | Baltimore, MD, USA
+VERSION='"v1.3.0.0-dev"'
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
@@ -23,14 +23,18 @@ VERSION='"v1.0.3.2-dev"'
 USING_CUDA = NO
 #OPT += -DUSE_SINGLE_PRECISION
 
+#------------------------------- Options for the force calculation method (if everthing is commented out, direct summation is used)
+#OPT += -DUSE_BH=0.25 # Use the Barnes-Hut (OctTree) method for force calculation with an opening angle of 0.25. (Recommended value is 0.25)
+#OPT += -DRANDOMIZE_BH=123456 # Randomize the BH tree to avoid artifacts. Only works with the BH method, and it is highly recommended to use it.
+
 #------------------------------- Options for boundary conditions (only uncomment one of them)
 #OPT += -DPERIODIC # Periodic boundary conditions
 #OPT += -DPERIODIC_Z # Periodic boundary conditions in the z-direction only
 
-#------------------------------- Option of HDF5
+#------------------------------- Option for enabling HDF5 I/O
 OPT += -DHAVE_HDF5
 
-#------------------------------- Glass making option
+#------------------------------- Option for turning on glass making mode
 #OPT += -DGLASS_MAKING
 
 #------------------------------- Parametrization of the background cosmology

--- a/StePS/Template-LinuxICC-Makefile
+++ b/StePS/Template-LinuxICC-Makefile
@@ -1,12 +1,12 @@
 
 #-----------------------------------------------------------------------------------------------#
 # StePS Makefile
-# Copyright (C) 2017-2025 Gabor Racz et al.
+# Copyright (C) 2017-2025 Gabor Racz
 #		Department of Physics, University of Helsinki | Helsinki, Finland
-#	Jet Propulsion Laboratory, California Institute of Technology | Pasadena, CA, USA
-# 	Department of Physics of Complex Systems, Eotvos Lorand University | Budapest, Hungary
-# 	Department of Physics & Astronomy, Johns Hopkins University | Baltimore, MD, USA
-VERSION='"v1.0.3.2-dev"'
+#		Jet Propulsion Laboratory, California Institute of Technology | Pasadena, CA, USA
+# 		Department of Physics of Complex Systems, Eotvos Lorand University | Budapest, Hungary
+# 		Department of Physics & Astronomy, Johns Hopkins University | Baltimore, MD, USA
+VERSION='"v1.3.0.0-dev"'
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
@@ -23,14 +23,18 @@ VERSION='"v1.0.3.2-dev"'
 USING_CUDA = YES
 OPT += -DUSE_SINGLE_PRECISION
 
+#------------------------------- Options for the force calculation method (if everthing is commented out, direct summation is used)
+#OPT += -DUSE_BH=0.25 # Use the Barnes-Hut (OctTree) method for force calculation with an opening angle of 0.25. (Recommended value is 0.25)
+#OPT += -DRANDOMIZE_BH=123456 # Randomize the BH tree to avoid artifacts. Only works with the BH method, and it is highly recommended to use it.
+
 #------------------------------- Options for boundary conditions (only uncomment one of them)
 #OPT += -DPERIODIC # Periodic boundary conditions
 #OPT += -DPERIODIC_Z # Periodic boundary conditions in the z-direction only
 
-#------------------------------- Option of HDF5
+#------------------------------- Option for enabling HDF5 I/O
 OPT += -DHAVE_HDF5
 
-#------------------------------- Glass making option
+#------------------------------- Option for turning on glass making mode
 #OPT += -DGLASS_MAKING
 
 #------------------------------- Parametrization of the background cosmology

--- a/StePS/src/forces.cc
+++ b/StePS/src/forces.cc
@@ -21,7 +21,6 @@
 #include "mpi.h"
 #include "global_variables.h"
 
-
 extern int e[2202][4];
 extern REAL w[3];
 extern int N, el;
@@ -39,6 +38,91 @@ void recalculate_softening()
 		rho_part = M_min/(4.0*pi*pow(beta, 3.0) / 3.0);
 	}
 }
+#if defined(USE_BH)
+// Oct-tree struct
+typedef struct OctreeNode
+{
+	REAL cx, cy, cz;		  // center of the cube
+	REAL nodesize;			      // length of the cube
+	REAL mass;
+	REAL com_x, com_y, com_z;  // center of mass
+	int particle_index;		   // -1 if internal node
+	struct OctreeNode *children[8];
+} OctreeNode;
+
+
+OctreeNode* create_node(REAL cx, REAL cy, REAL cz, REAL nodesize)
+{
+    OctreeNode *node = (OctreeNode*)malloc(sizeof(OctreeNode));
+    node->cx = cx; node->cy = cy; node->cz = cz;
+    node->nodesize = nodesize;
+    node->mass = 0;
+    node->com_x = node->com_y = node->com_z = 0;
+    node->particle_index = -1;
+    for (int i = 0; i < 8; i++) node->children[i] = NULL;
+    return node;
+}
+
+int get_octant(OctreeNode *node, REAL *X, int i)
+{
+    int index = 0;
+    if (X[3*i]     > node->cx) index |= 1;
+    if (X[3*i + 1] > node->cy) index |= 2;
+    if (X[3*i + 2] > node->cz) index |= 4;
+    return index;
+}
+
+void insert_particle(OctreeNode *node, REAL *X, REAL *M, int i)
+{
+    if (node->mass == 0 && node->particle_index == -1)
+    {
+        node->particle_index = i;
+        node->mass = M[i];
+        node->com_x = X[3*i];
+        node->com_y = X[3*i+1];
+        node->com_z = X[3*i+2];
+        return;
+    }
+
+    if (node->particle_index != -1)
+    {
+        int existing = node->particle_index;
+        node->particle_index = -1;
+
+        for (int j = 0; j < 8; j++)
+        {
+            REAL offset = node->nodesize / 4;
+            REAL new_cx = node->cx + ((j & 1) ? offset : -offset);
+            REAL new_cy = node->cy + ((j & 2) ? offset : -offset);
+            REAL new_cz = node->cz + ((j & 4) ? offset : -offset);
+            node->children[j] = create_node(new_cx, new_cy, new_cz, node->nodesize / 2);
+        }
+
+        int oct = get_octant(node, X, existing);
+        insert_particle(node->children[oct], X, M, existing);
+    }
+
+    int oct = get_octant(node, X, i);
+    insert_particle(node->children[oct], X, M, i);
+
+    REAL total_mass = node->mass + M[i];
+    node->com_x = (node->com_x * node->mass + X[3*i] * M[i]) / total_mass;
+    node->com_y = (node->com_y * node->mass + X[3*i+1] * M[i]) / total_mass;
+    node->com_z = (node->com_z * node->mass + X[3*i+2] * M[i]) / total_mass;
+    node->mass = total_mass;
+}
+void free_node(OctreeNode *node)
+{
+	// Free the node and its children (and their children, recursively)
+	if (node == NULL) return;
+	for (int i = 0; i < 8; i++)
+    {
+		free_node(node->children[i]);
+	}
+	free(node);
+
+}
+#endif
 
 #if defined(PERIODIC_Z)
 
@@ -91,25 +175,229 @@ REAL get_cylindrical_force_correction(REAL r, REAL R, REAL *FORCE_TABLE, int TAB
 #endif
 
 #if !defined(PERIODIC) && !defined(PERIODIC_Z)
+// Free StePS boundary conditions
+#if defined(USE_BH)
+// Barnes-Hut oct-tree force calculation
+
+#ifdef RANDOMIZE_BH
+void rotate_vectors(REAL* CoordArray, const REAL* Y, REAL ROT_RAD, int idmin, int idmax)
+{
+	// 3D rotation of all coordinates around the Y axis with ROT_RAD radians by using Rodrigues' rotation formula
+    REAL cos_theta = cos(ROT_RAD);
+    REAL sin_theta = sin(ROT_RAD);
+
+	for(int i = idmin; i < idmax+1; ++i)
+	{
+		REAL X[3] = {CoordArray[3*i], CoordArray[3*i+1], CoordArray[3*i+2]};
+
+		// Cross product Y x X
+		REAL cross[3] = {
+			Y[1] * X[2] - Y[2] * X[1],
+			Y[2] * X[0] - Y[0] * X[2],
+			Y[0] * X[1] - Y[1] * X[0]
+		};
+
+		// Dot product Y * X
+		REAL dot = Y[0] * X[0] + Y[1] * X[1] + Y[2] * X[2];
+
+		// Rodrigues' rotation formula
+		REAL rotated[3];
+		for (int i = 0; i < 3; ++i)
+		{
+			rotated[i] = X[i] * cos_theta + cross[i] * sin_theta + Y[i] * dot * (1.0 - cos_theta);
+		}
+
+		// Store result back to the original array
+		CoordArray[3*i] = rotated[0];
+		CoordArray[3*i+1] = rotated[1];
+		CoordArray[3*i+2] = rotated[2];
+	}
+}
+
+void random_unit_vector(double* vec)
+{
+	// Generate a random unit vector in 3D space
+    double theta = ((double)rand() / RAND_MAX) * 2.0 * M_PI;
+    double z = ((double)rand() / RAND_MAX) * 2.0 - 1.0;
+    double r = sqrt(1.0 - z * z);
+
+    vec[0] = r * cos(theta);
+    vec[1] = r * sin(theta);
+    vec[2] = z;
+}
+
+#endif
+
+void compute_BH_force(OctreeNode *node, REAL *X, int i, REAL *SOFT_LENGTH, REAL *fx, REAL *fy, REAL *fz)
+{
+    if (node == NULL || (node->mass == 0) || (node->particle_index == i)) return;
+
+	REAL SOFT_CONST[5];
+	REAL wij, beta, betap2;
+
+    REAL dx = node->com_x - X[3*i];
+    REAL dy = node->com_y - X[3*i+1];
+    REAL dz = node->com_z - X[3*i+2];
+    REAL dist = sqrt(dx*dx + dy*dy + dz*dz);
+
+    if (node->particle_index != -1 || node->nodesize / dist < THETA)
+    {
+		beta = cbrt(node->mass / M_min)*ParticleRadi + SOFT_LENGTH[i];
+		betap2 = beta*0.5;
+		if (dist >= beta)
+        {
+        		wij = node->mass /(pow(dist,3));
+		}
+		else if(dist > betap2 && dist < beta)
+        {
+				SOFT_CONST[0] = -32.0/(3.0*pow(beta, 6));
+				SOFT_CONST[1] = 38.4/pow(beta, 5);
+				SOFT_CONST[2] = -48.0/pow(beta, 4);
+				SOFT_CONST[3] = 64.0/(3.0*pow(beta, 3));
+				SOFT_CONST[4] = -1.0/15.0;
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]*dist+SOFT_CONST[3]+SOFT_CONST[4]/pow(dist, 3));
+		}
+		else
+        {
+                SOFT_CONST[0] = 32.0/pow(beta, 6);
+				SOFT_CONST[1] = -38.4/pow(beta, 5);
+				SOFT_CONST[2] = 32.0/(3.0*pow(beta, 3));
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]);
+
+		}
+        *fx += wij * dx;
+        *fy += wij * dy;
+        *fz += wij * dz;
+    }
+    else
+    {
+        for (int j = 0; j < 8; j++)
+        {
+            compute_BH_force(node->children[j], X, i, SOFT_LENGTH, fx, fy, fz);
+        }
+    }
+}
+
 void forces(REAL* x, REAL* F, int ID_min, int ID_max) //Force calculation
 {
-//timing
-double omp_start_time = omp_get_wtime();
-//timing
-REAL Fx_tmp, Fy_tmp, Fz_tmp, beta_priv, beta_privp2;
-REAL SOFT_CONST[5];
-
-REAL DE = (REAL) H0*H0*Omega_lambda;
-
-int i, j, k, chunk;
-for(i=0; i<N_mpi_thread; i++)
-{
-        for(k=0; k<3; k++)
+    //timing
+    double omp_start_time = omp_get_wtime();
+    //timing
+    REAL Fx_tmp, Fy_tmp, Fz_tmp;
+    REAL DE = (REAL) H0*H0*Omega_lambda;
+    int i, k, chunk;
+	REAL domain_center[3];
+	REAL RootNodeSize;
+    //Building the octree
+	// Identifying the most outer particle radius
+	REAL radius_tmp, Max_radius = 0.0;
+	for (int i = 0; i < N; i++)
+    {
+		radius_tmp = sqrt(pow(x[3*i], 2) + pow(x[3*i+1], 2) + pow(x[3*i+2], 2));
+		if (radius_tmp > Max_radius)
         {
-                F[3*i+k] = 0;
-        }
+			Max_radius = radius_tmp;
+		}
+	}
+	#ifdef RANDOMIZE_BH
+	REAL rotation_axis[3];
+	REAL rotation_angle;
+    //generating the random shift vector (100% of the maximum radius)
+	for(i=0; i<3; i++)
+	{
+		domain_center[i] = ((REAL)rand()/(REAL)RAND_MAX-0.5)*2.0*Max_radius;
+	}
+	RootNodeSize = 4.00004 * Max_radius; //size of the root node (2Dsim+epsilon)
+	rotation_angle = (REAL)rand()/(REAL)RAND_MAX * pi;
+	random_unit_vector(rotation_axis);
+	printf("MPI task %i: Octree force calculation started with random %.3f RAD rotation along the\n\t    (%.3f, %.3f, %.3f) axis vector, and with random domain center (%.3f, %.3f, %.3f).\n", rank, rotation_angle, rotation_axis[0], rotation_axis[1], rotation_axis[2], domain_center[0], domain_center[1], domain_center[2]);
+	// Rotate the coordinates
+	rotate_vectors(x, rotation_axis, rotation_angle, 0, N-1);
+	#else
+	domain_center[0] = domain_center[1] = domain_center[2] = 0.0;
+	RootNodeSize = 2.00002 * Max_radius; //size of the root node (Dsim+epsilon)
+	#endif
+	if(rank==0)
+		printf("\t    Root node size: %.6g Mpc.\n", RootNodeSize);
+    OctreeNode *rootnode = create_node(domain_center[0], domain_center[1], domain_center[2], RootNodeSize); //centered at domain_center, size RootNodeSize
+    for (int i = 0; i < N; i++)
+    {
+        // Insert particles into the octree
+        insert_particle(rootnode, x, M, i);
+    }
+    for(i=0; i<N_mpi_thread; i++)
+    {
+            for(k=0; k<3; k++)
+            {
+                    F[3*i+k] = 0;
+            }
+    }
+	chunk = (ID_max-ID_min)/omp_get_max_threads()/4;
+	if(chunk < 1)
+	{
+		chunk = 1;
+	}
+	#pragma omp parallel default(shared)  private(i, Fx_tmp, Fy_tmp, Fz_tmp)
+	{
+	#pragma omp for schedule(dynamic,chunk)
+	for(i=ID_min; i<ID_max+1; i++)
+	{
+		Fx_tmp = Fy_tmp = Fz_tmp = 0.0;
+        compute_BH_force(rootnode, x, i, SOFT_LENGTH, &Fx_tmp, &Fy_tmp, &Fz_tmp);
+        #pragma omp atomic
+            F[3*(i-ID_min)] += Fx_tmp;
+		#pragma omp atomic
+            F[3*(i-ID_min)+1] += Fy_tmp;
+		#pragma omp atomic
+            F[3*(i-ID_min)+2] += Fz_tmp;
+		if(COSMOLOGY == 1 && COMOVING_INTEGRATION == 1)//Adding the external force from the outside of the simulation volume, if we run non-periodic comoving cosmological simulation
+		{
+			F[3*(i-ID_min)] += mass_in_unit_sphere * x[3*i];
+			F[3*(i-ID_min)+1] += mass_in_unit_sphere * x[3*i+1];
+			F[3*(i-ID_min)+2] += mass_in_unit_sphere * x[3*i+2];
+		}
+		else if(COSMOLOGY == 1 && COMOVING_INTEGRATION == 0)
+		{
+			F[3*(i-ID_min)] +=  DE * x[3*i];
+			F[3*(i-ID_min)+1] += DE * x[3*i+1];
+			F[3*(i-ID_min)+2] += DE * x[3*i+2];
+		}
+	}
+    }
+	free_node(rootnode);
+	// Rotating the coordinates and forces back to the original orientation
+	#ifdef RANDOMIZE_BH
+	rotate_vectors(x, rotation_axis, -rotation_angle, 0, N-1);
+	rotate_vectors(F, rotation_axis, -rotation_angle, ID_min, ID_max);
+	#endif
+	//timing
+	double omp_end_time = omp_get_wtime();
+	//timing
+	printf("Octree force calculation finished on MPI task %i. Force calculation wall-clock time = %fs.\n", rank, omp_end_time-omp_start_time);
+	return;
 }
-        REAL r, dx, dy, dz, wij;
+
+#else
+// Direct summation force calculation
+void forces(REAL* x, REAL* F, int ID_min, int ID_max) //Force calculation
+{
+	REAL Fx_tmp, Fy_tmp, Fz_tmp, beta_priv, beta_privp2;
+	REAL SOFT_CONST[5];
+	REAL DE = (REAL) H0*H0*Omega_lambda;
+
+	//timing
+    double omp_start_time = omp_get_wtime();
+    //timing
+
+	int i, j, k, chunk;
+	for(i=0; i<N_mpi_thread; i++)
+	{
+			for(k=0; k<3; k++)
+			{
+					F[3*i+k] = 0;
+			}
+	}
+    REAL r, dx, dy, dz, wij;
 	chunk = (ID_max-ID_min)/omp_get_max_threads();
 	if(chunk < 1)
 	{
@@ -135,7 +423,7 @@ for(i=0; i<N_mpi_thread; i++)
 				wij = M[j]/(pow(r, 3));
 			}
 			else if(r > beta_privp2 && r < beta_priv)
-                        {
+            {
 				SOFT_CONST[0] = -32.0/(3.0*pow(beta_priv, 6));
 				SOFT_CONST[1] = 38.4/pow(beta_priv, 5);
 				SOFT_CONST[2] = -48.0/pow(beta_priv, 4);
@@ -160,9 +448,7 @@ for(i=0; i<N_mpi_thread; i++)
                         F[3*(i-ID_min)+1] += Fy_tmp;
 			#pragma omp atomic
                         F[3*(i-ID_min)+2] += Fz_tmp;
-
-
-                }
+        }
 		if(COSMOLOGY == 1 && COMOVING_INTEGRATION == 1)//Adding the external force from the outside of the simulation volume, if we run non-periodic comoving cosmological simulation
 		{
 			F[3*(i-ID_min)] += mass_in_unit_sphere * x[3*i];
@@ -181,19 +467,256 @@ for(i=0; i<N_mpi_thread; i++)
 //timing
 double omp_end_time = omp_get_wtime();
 //timing
-printf("Force calculation finished on MPI task %i. Force calculation wall-clock time = %fs.\n", rank, omp_end_time-omp_start_time);
+printf("Direct force calculation finished on MPI task %i. Force calculation wall-clock time = %fs.\n", rank, omp_end_time-omp_start_time);
 return;
 }
 #endif
+#endif
 
 #ifdef PERIODIC
+#if defined(USE_BH)
+//Barnes-Hut oct-tree force calculation with multiple images
+void compute_BH_force(OctreeNode *node, REAL *X, int i, REAL COORD_X, REAL COORD_Y, REAL COORD_Z, REAL *SOFT_LENGTH, REAL ewald_cut, REAL *fx, REAL *fy, REAL *fz)
+{
+    if (node == NULL || (node->mass == 0) || (node->particle_index == i)) return;
+
+	REAL SOFT_CONST[5];
+	REAL wij, beta, betap2;
+
+    REAL dx = node->com_x - COORD_X;
+    REAL dy = node->com_y - COORD_Y;
+    REAL dz = node->com_z - COORD_Z;
+    REAL dist = sqrt(dx*dx + dy*dy + dz*dz);
+    if (node->particle_index != -1 || node->nodesize / dist < THETA)
+    {
+		if (dist > ewald_cut) return; // Skip if outside the cutoff radius
+		beta = cbrt(node->mass / M_min)*ParticleRadi + SOFT_LENGTH[i];
+		betap2 = beta*0.5;
+		if (dist >= beta)
+        {
+        		wij = node->mass /(pow(dist,3));
+		}
+		else if(dist > betap2 && dist < beta)
+        {
+				SOFT_CONST[0] = -32.0/(3.0*pow(beta, 6));
+				SOFT_CONST[1] = 38.4/pow(beta, 5);
+				SOFT_CONST[2] = -48.0/pow(beta, 4);
+				SOFT_CONST[3] = 64.0/(3.0*pow(beta, 3));
+				SOFT_CONST[4] = -1.0/15.0;
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]*dist+SOFT_CONST[3]+SOFT_CONST[4]/pow(dist, 3));
+		}
+		else
+        {
+                SOFT_CONST[0] = 32.0/pow(beta, 6);
+				SOFT_CONST[1] = -38.4/pow(beta, 5);
+				SOFT_CONST[2] = 32.0/(3.0*pow(beta, 3));
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]);
+
+		}
+        *fx += wij * dx;
+        *fy += wij * dy;
+        *fz += wij * dz;
+    }
+    else
+    {
+        for (int j = 0; j < 8; j++)
+        {
+            compute_BH_force(node->children[j], X, i, COORD_X, COORD_Y, COORD_Z, SOFT_LENGTH, ewald_cut, fx, fy, fz);
+        }
+    }
+}
+
+void compute_BH_QP_force(OctreeNode *node, REAL *X, int i, REAL *SOFT_LENGTH, REAL boxsize, REAL *fx, REAL *fy, REAL *fz)
+{
+	//quasi-periodic force calculation
+    if (node == NULL || (node->mass == 0) || (node->particle_index == i)) return;
+
+	REAL SOFT_CONST[5];
+	REAL wij, beta, betap2;
+
+    REAL dx = node->com_x - X[3*i];
+    REAL dy = node->com_y - X[3*i+1];
+    REAL dz = node->com_z - X[3*i+2];
+    //in this case we use only the nearest image of the node
+	if(fabs(dx)>0.5*boxsize)
+		dx = dx-boxsize*dx/fabs(dx);
+	if(fabs(dy)>0.5*boxsize)
+		dy = dy-boxsize*dy/fabs(dy);
+	if(fabs(dz)>0.5*boxsize)
+		dz = dz-boxsize*dz/fabs(dz);
+	REAL dist = sqrt(pow(dx, 2)+pow(dy, 2)+pow(dz, 2));
+    if (node->particle_index != -1 || node->nodesize / dist < THETA)
+    {
+		beta = cbrt(node->mass / M_min)*ParticleRadi + SOFT_LENGTH[i];
+		betap2 = beta*0.5;
+		if (dist >= beta)
+        {
+        		wij = node->mass /(pow(dist,3));
+		}
+		else if(dist > betap2 && dist < beta)
+        {
+				SOFT_CONST[0] = -32.0/(3.0*pow(beta, 6));
+				SOFT_CONST[1] = 38.4/pow(beta, 5);
+				SOFT_CONST[2] = -48.0/pow(beta, 4);
+				SOFT_CONST[3] = 64.0/(3.0*pow(beta, 3));
+				SOFT_CONST[4] = -1.0/15.0;
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]*dist+SOFT_CONST[3]+SOFT_CONST[4]/pow(dist, 3));
+		}
+		else
+        {
+                SOFT_CONST[0] = 32.0/pow(beta, 6);
+				SOFT_CONST[1] = -38.4/pow(beta, 5);
+				SOFT_CONST[2] = 32.0/(3.0*pow(beta, 3));
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]);
+
+		}
+        *fx += wij * dx;
+        *fy += wij * dy;
+        *fz += wij * dz;
+    }
+    else
+    {
+        for (int j = 0; j < 8; j++)
+        {
+            compute_BH_QP_force(node->children[j], X, i, SOFT_LENGTH, boxsize, fx, fy, fz);
+        }
+    }
+}
+
 void forces_periodic(REAL*x, REAL*F, int ID_min, int ID_max) //force calculation with multiple images
 {
-//timing
-double omp_start_time = omp_get_wtime();
-//timing
-REAL Fx_tmp, Fy_tmp, Fz_tmp, beta_priv, beta_privp2;
-REAL SOFT_CONST[5];
+	//timing
+	double omp_start_time = omp_get_wtime();
+	//timing
+	REAL Fx_tmp, Fy_tmp, Fz_tmp, EwaldCut;
+	int i, k, m, chunk;
+	#ifdef RANDOMIZE_BH
+	//generating the random shift vector
+	REAL random_shift[3];
+	for(i=0; i<3; i++)
+	{
+		random_shift[i] = ((REAL)rand()/(REAL)RAND_MAX-0.5)*L;
+	}
+	printf("MPI task %i: Octree force calculation started with random shift vector (%.3f %.3f %.3f).\n", rank, random_shift[0], random_shift[1], random_shift[2]);
+	// Shifting the particles by the random vector with periodic boundary conditions
+	for(i=0; i<N; i++)
+	{
+		for(k=0; k<3; k++)
+		{
+			x[3*i+k] += random_shift[k];
+			if(x[3*i+k]<0)
+			{
+				x[3*i+k] = x[3*i+k] + L;
+			}
+			else if(x[3*i+k]>=L)
+			{
+				x[3*i+k] = x[3*i+k] - L;
+			}
+		}
+	}
+	#endif
+	//Building the octree
+	if(rank==0)
+		printf("\t    Root node size: %.6g Mpc.\n", L);
+    OctreeNode *rootnode = create_node(0.50*L, 0.50*L, 0.50*L, L); //center of the simulation box, size L
+    for (int i = 0; i < N; i++)
+    {
+        // Insert particles into the octree
+        insert_particle(rootnode, x, M, i);
+    }
+    for(i=0; i<N_mpi_thread; i++)
+    {
+		for(k=0; k<3; k++)
+		{
+			F[3*i+k] = 0;
+		}
+    }
+	chunk = (ID_max-ID_min)/(omp_get_max_threads())/4;
+	if(chunk < 1)
+	{
+		chunk = 1;
+	}
+	if(IS_PERIODIC>=2)
+	{
+		// Ewald summation with multiple images
+		if(IS_PERIODIC==2)
+			EwaldCut = 2.6*L; // Ewald cutoff radius
+		else
+			EwaldCut = 4.6*L; // Ewald cutoff radius
+		#pragma omp parallel default(shared)  private(i, m, Fx_tmp, Fy_tmp, Fz_tmp)
+		{
+		#pragma omp for schedule(dynamic,chunk)
+		for(i=ID_min; i<ID_max+1; i++)
+		{
+			//using multiple images
+			for(m=0;m<el;m++)
+			{
+				Fx_tmp = Fy_tmp = Fz_tmp = 0.0;
+				compute_BH_force(rootnode, x, i, x[3*i]+((REAL) e[m][0])*L, x[3*i+1]+((REAL) e[m][1])*L, x[3*i+2]+((REAL) e[m][2])*L, SOFT_LENGTH, EwaldCut, &Fx_tmp, &Fy_tmp, &Fz_tmp);
+				#pragma omp atomic
+					F[3*(i-ID_min)] += Fx_tmp;
+				#pragma omp atomic
+					F[3*(i-ID_min)+1] += Fy_tmp;
+				#pragma omp atomic
+					F[3*(i-ID_min)+2] += Fz_tmp;
+			}
+		}
+		}
+	}
+	else
+	{
+		//quasi-periodic force calculation with multiple images
+		#pragma omp parallel default(shared)  private(i, Fx_tmp, Fy_tmp, Fz_tmp)
+        {
+        	#pragma omp for schedule(dynamic,chunk)
+	        for(i=ID_min; i<ID_max+1; i++)
+			{
+				Fx_tmp = Fy_tmp = Fz_tmp = 0.0;
+				compute_BH_QP_force(rootnode, x, i, SOFT_LENGTH, L, &Fx_tmp, &Fy_tmp, &Fz_tmp);
+				#pragma omp atomic
+					F[3*(i-ID_min)] += Fx_tmp;
+				#pragma omp atomic
+					F[3*(i-ID_min)+1] += Fy_tmp;
+				#pragma omp atomic
+					F[3*(i-ID_min)+2] += Fz_tmp;
+			}
+		}	
+	}
+	free_node(rootnode);
+	#ifdef RANDOMIZE_BH
+	// Shifting back the particles to their original position with periodic boundary conditions
+	for(i=0; i<N; i++)
+	{
+		for(k=0; k<3; k++)
+		{
+			x[3*i+k] -= random_shift[k];
+			if(x[3*i+k]<0)
+			{
+				x[3*i+k] = x[3*i+k] + L;
+			}
+			else if(x[3*i+k]>=L)
+			{
+				x[3*i+k] = x[3*i+k] - L;
+			}
+		}
+	}
+	#endif
+	//timing
+	double omp_end_time = omp_get_wtime();
+	//timing
+	printf("Octree force calculation finished on MPI task %i. Force calculation wall-clock time = %fs.\n", rank, omp_end_time-omp_start_time);
+	return;
+}
+
+#else
+//Direct summation force calculation with multiple images
+void forces_periodic(REAL*x, REAL*F, int ID_min, int ID_max) //force calculation with multiple images
+{
+	//timing
+	double omp_start_time = omp_get_wtime();
+	//timing
+	REAL Fx_tmp, Fy_tmp, Fz_tmp, beta_priv, beta_privp2, EwaldCut;
+	REAL SOFT_CONST[5];
 	int i, j, k, m, chunk;
 	for(i=0; i<N_mpi_thread; i++)
 	{
@@ -210,63 +733,67 @@ REAL SOFT_CONST[5];
 	}
 	if(IS_PERIODIC>=2)
 	{
-	#pragma omp parallel default(shared)  private(dx, dy, dz, r, wij, i, j, m, Fx_tmp, Fy_tmp, Fz_tmp, SOFT_CONST, beta_priv, beta_privp2)
-	{
-	#pragma omp for schedule(dynamic,chunk)
-	for(i=ID_min; i<ID_max+1; i++)
-	{
-		for(j=0; j<N; j++)
+		if(IS_PERIODIC==2)
+			EwaldCut = 2.6*L; // Ewald cutoff radius
+		else
+			EwaldCut = 4.6*L; // Ewald cutoff radius
+		#pragma omp parallel default(shared)  private(dx, dy, dz, r, wij, i, j, m, Fx_tmp, Fy_tmp, Fz_tmp, SOFT_CONST, beta_priv, beta_privp2)
 		{
-			Fx_tmp = 0;
-			Fy_tmp = 0;
-			Fz_tmp = 0;
-			beta_priv = (SOFT_LENGTH[i]+SOFT_LENGTH[j]);
-			beta_privp2 = beta_priv*0.5; 
-			//calculating particle distances inside the simulation box
-			dx=x[3*j]-x[3*i];
-			dy=x[3*j+1]-x[3*i+1];
-			dz=x[3*j+2]-x[3*i+2];
-			//In here we use multiple images
-			for(m=0;m<el;m++)
+		#pragma omp for schedule(dynamic,chunk)
+		for(i=ID_min; i<ID_max+1; i++)
+		{
+			for(j=0; j<N; j++)
 			{
-				r = sqrt(pow((dx-((REAL) e[m][0])*L), 2)+pow((dy-((REAL) e[m][1])*L), 2)+pow((dz-((REAL) e[m][2])*L), 2));
-				wij = 0;
-				if(r >= beta_priv && r < 2.6*L)
+				Fx_tmp = 0;
+				Fy_tmp = 0;
+				Fz_tmp = 0;
+				beta_priv = (SOFT_LENGTH[i]+SOFT_LENGTH[j]);
+				beta_privp2 = beta_priv*0.5; 
+				//calculating particle distances inside the simulation box
+				dx=x[3*j]-x[3*i];
+				dy=x[3*j+1]-x[3*i+1];
+				dz=x[3*j+2]-x[3*i+2];
+				//In here we use multiple images
+				for(m=0;m<el;m++)
 				{
-					wij = M[j]/(pow(r, 3));
+					r = sqrt(pow((dx-((REAL) e[m][0])*L), 2)+pow((dy-((REAL) e[m][1])*L), 2)+pow((dz-((REAL) e[m][2])*L), 2));
+					wij = 0;
+					if(r >= beta_priv && r < EwaldCut)
+					{
+						wij = M[j]/(pow(r, 3));
+					}
+					else if(r > beta_privp2 && r < beta_priv)
+					{
+						SOFT_CONST[0] = -32.0/(3.0*pow(beta_priv, 6));
+						SOFT_CONST[1] = 38.4/pow(beta_priv, 5);
+						SOFT_CONST[2] = -48.0/pow(beta_priv, 4);
+						SOFT_CONST[3] = 64.0/(3.0*pow(beta_priv, 3));
+						SOFT_CONST[4] = -1.0/15.0;
+						wij = M[j]*(SOFT_CONST[0]*pow(r, 3)+SOFT_CONST[1]*pow(r, 2)+SOFT_CONST[2]*r+SOFT_CONST[3]+SOFT_CONST[4]/pow(r, 3));
+					}
+					else if(r <= beta_privp2)
+					{
+						SOFT_CONST[0] = 32.0/pow(beta_priv, 6);
+										SOFT_CONST[1] = -38.4/pow(beta_priv, 5);
+										SOFT_CONST[2] = 32.0/(3.0*pow(beta_priv, 3));
+						wij = M[j]*(SOFT_CONST[0]*pow(r, 3)+SOFT_CONST[1]*pow(r, 2)+SOFT_CONST[2]);
+					}
+					if(wij != 0)
+					{
+						Fx_tmp += wij*(dx-((REAL) e[m][0])*L);
+						Fy_tmp += wij*(dy-((REAL) e[m][1])*L);
+						Fz_tmp += wij*(dz-((REAL) e[m][2])*L);
+					}
 				}
-				else if(r > beta_privp2 && r < beta_priv)
-				{
-					SOFT_CONST[0] = -32.0/(3.0*pow(beta_priv, 6));
-					SOFT_CONST[1] = 38.4/pow(beta_priv, 5);
-					SOFT_CONST[2] = -48.0/pow(beta_priv, 4);
-					SOFT_CONST[3] = 64.0/(3.0*pow(beta_priv, 3));
-					SOFT_CONST[4] = -1.0/15.0;
-					wij = M[j]*(SOFT_CONST[0]*pow(r, 3)+SOFT_CONST[1]*pow(r, 2)+SOFT_CONST[2]*r+SOFT_CONST[3]+SOFT_CONST[4]/pow(r, 3));
-				}
-				else if(r <= beta_privp2)
-				{
-					SOFT_CONST[0] = 32.0/pow(beta_priv, 6);
-        	                        SOFT_CONST[1] = -38.4/pow(beta_priv, 5);
-	                                SOFT_CONST[2] = 32.0/(3.0*pow(beta_priv, 3));
-					wij = M[j]*(SOFT_CONST[0]*pow(r, 3)+SOFT_CONST[1]*pow(r, 2)+SOFT_CONST[2]);
-				}
-				if(wij != 0)
-				{
-					Fx_tmp += wij*(dx-((REAL) e[m][0])*L);
-					Fy_tmp += wij*(dy-((REAL) e[m][1])*L);
-					Fz_tmp += wij*(dz-((REAL) e[m][2])*L);
-				}
+				#pragma omp atomic
+							F[3*(i-ID_min)] += Fx_tmp;
+				#pragma omp atomic
+							F[3*(i-ID_min)+1] += Fy_tmp;
+				#pragma omp atomic
+							F[3*(i-ID_min)+2] += Fz_tmp;
 			}
-			#pragma omp atomic
-                        F[3*(i-ID_min)] += Fx_tmp;
-			#pragma omp atomic
-                        F[3*(i-ID_min)+1] += Fy_tmp;
-			#pragma omp atomic
-                        F[3*(i-ID_min)+2] += Fz_tmp;
+			}
 		}
-		}
-	}
 	}
 	else
 	{
@@ -328,13 +855,332 @@ REAL SOFT_CONST[5];
 //timing
 double omp_end_time = omp_get_wtime();
 //timing
-printf("Force calculation finished on MPI task %i. Force calculation wall-clock time = %fs.\n", rank, omp_end_time-omp_start_time);
+printf("Direct force calculation finished on MPI task %i. Force calculation wall-clock time = %fs.\n", rank, omp_end_time-omp_start_time);
 return;
 }
 #endif
+#endif
 
 #ifdef PERIODIC_Z
-//force calculation with multiple images only in the z direction
+#if defined(USE_BH)
+//Barnes-Hut oct-tree force calculation with multiple images in the z direction only
+
+#ifdef RANDOMIZE_BH
+void rotate_vectors_2d(REAL* CoordArray, REAL ROT_RAD, int idmin, int idmax)
+{
+	//2D Rotation in the x-y plane with ROT_RAD radians.
+	REAL cos_theta = cos(ROT_RAD);
+	REAL sin_theta = sin(ROT_RAD);
+	REAL rotated[2];
+	for(int i = idmin; i < idmax+1; ++i)
+	{
+		rotated[0] = CoordArray[3*i]*cos_theta-CoordArray[3*i+1]*sin_theta;
+		rotated[1] = CoordArray[3*i]*sin_theta+CoordArray[3*i+1]*cos_theta;
+		// Store result back to the original array
+		CoordArray[3*i] = rotated[0];
+		CoordArray[3*i+1] = rotated[1];
+	}
+}
+#endif
+
+void compute_BH_force_z(OctreeNode *node, REAL *X, int i, REAL *SOFT_LENGTH, REAL COORD_X, REAL COORD_Y, REAL COORD_Z, REAL ewald_cut, REAL *fx, REAL *fy, REAL *fz)
+{
+	if (node == NULL || (node->mass == 0) || (node->particle_index == i)) return;
+
+	REAL SOFT_CONST[5];
+	REAL wij, beta, betap2;
+
+	REAL dx = node->com_x - COORD_X;
+	REAL dy = node->com_y - COORD_Y;
+	REAL dz = (node->com_z - COORD_Z);
+	REAL dist = sqrt(dx*dx + dy*dy + dz*dz);
+	if (node->particle_index != -1 || (node->nodesize) / dist < THETA)
+	{
+		if (fabs(dz) > ewald_cut) return;
+		beta = cbrt(node->mass / M_min)*ParticleRadi + SOFT_LENGTH[i];
+		betap2 = beta*0.5;
+		if (dist >= beta)
+		{
+				wij = node->mass /(pow(dist,3));
+		}
+		else if(dist > betap2 && dist < beta)
+		{
+				SOFT_CONST[0] = -32.0/(3.0*pow(beta, 6));
+				SOFT_CONST[1] = 38.4/pow(beta, 5);
+				SOFT_CONST[2] = -48.0/pow(beta, 4);
+				SOFT_CONST[3] = 64.0/(3.0*pow(beta, 3));
+				SOFT_CONST[4] = -1.0/15.0;
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]*dist+SOFT_CONST[3]+SOFT_CONST[4]/pow(dist, 3));
+		}
+		else
+		{
+				SOFT_CONST[0] = 32.0/pow(beta, 6);
+				SOFT_CONST[1] = -38.4/pow(beta, 5);
+				SOFT_CONST[2] = 32.0/(3.0*pow(beta, 3));
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]);
+		}
+		*fx += wij * dx;
+		*fy += wij * dy;
+		*fz += wij * dz;
+	}
+	else
+	{
+		for (int j = 0; j < 8; j++)
+		{
+			compute_BH_force_z(node->children[j], X, i, SOFT_LENGTH, COORD_X, COORD_Y, COORD_Z, ewald_cut, fx, fy, fz);
+		}
+	}
+}
+
+void compute_BH_QP_force_z(OctreeNode *node, REAL *X, int i, REAL *SOFT_LENGTH, REAL boxsize, REAL *fx, REAL *fy, REAL *fz)
+{
+	//quasi-periodic force calculation in the z direction only
+	if (node == NULL || (node->mass == 0) || (node->particle_index == i)) return;
+
+	REAL SOFT_CONST[5];
+	REAL wij, beta, betap2;
+
+	REAL dx = node->com_x - X[3*i];
+	REAL dy = node->com_y - X[3*i+1];
+	REAL dz = (node->com_z - X[3*i+2]);
+	//in this case we use only the nearest image of the node
+	if(fabs(dz)>0.5*boxsize)
+		dz = dz-boxsize*dz/fabs(dz);
+	REAL dist = sqrt(pow(dx, 2)+pow(dy, 2)+pow(dz, 2));
+	if (node->particle_index != -1 || (node->nodesize) / dist < THETA)
+	{
+		beta = cbrt(node->mass / M_min)*ParticleRadi + SOFT_LENGTH[i];
+		betap2 = beta*0.5;
+		if (dist >= beta)
+		{
+				wij = node->mass /(pow(dist,3));
+		}
+		else if(dist > betap2 && dist < beta)
+		{
+				SOFT_CONST[0] = -32.0/(3.0*pow(beta, 6));
+				SOFT_CONST[1] = 38.4/pow(beta, 5);
+				SOFT_CONST[2] = -48.0/pow(beta, 4);
+				SOFT_CONST[3] = 64.0/(3.0*pow(beta, 3));
+				SOFT_CONST[4] = -1.0/15.0;
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist,2)+SOFT_CONST[2]*dist+SOFT_CONST[3]+SOFT_CONST[4]/pow(dist, 3));
+		}
+		else
+		{
+				SOFT_CONST[0] = 32.0/pow(beta, 6);
+				SOFT_CONST[1] = -38.4/pow(beta, 5);
+				SOFT_CONST[2] = 32.0/(3.0*pow(beta, 3));
+				wij = node->mass*(SOFT_CONST[0]*pow(dist, 3)+SOFT_CONST[1]*pow(dist, 2)+SOFT_CONST[2]);
+		}
+		*fx += wij * dx;
+		*fy += wij * dy;
+		*fz += wij * dz;
+	}
+	else
+	{
+		for (int j = 0; j < 8; j++)
+		{
+			compute_BH_QP_force_z(node->children[j], X, i, SOFT_LENGTH, boxsize, fx, fy, fz);
+		}
+	}
+}
+
+void forces_periodic_z(REAL* x, REAL* F, int ID_min, int ID_max)
+{
+    //timing
+    double omp_start_time = omp_get_wtime();
+    //timing
+    REAL Fx_tmp, Fy_tmp, Fz_tmp, r_xy, cylindrical_force_correction, RootNodeSize, EwaldCut;
+	REAL random_shift[3];
+	REAL DE = (REAL) H0*H0*Omega_lambda;
+    int i, k, m, chunk;
+    for(i=0; i<N_mpi_thread; i++)
+    {
+        for(k=0; k<3; k++)
+        {
+            F[3*i+k] = 0;
+        }
+    }
+    //Building the octree
+	// Identifying the most outer particle radius
+	REAL radius_tmp, Max_radius = 0.0;
+	for (int i = 0; i < N; i++)
+    {
+		radius_tmp = sqrt(pow(x[3*i], 2) + pow(x[3*i+1], 2));
+		if (radius_tmp > Max_radius)
+        {
+			Max_radius = radius_tmp;
+		}
+	}
+	#ifdef RANDOMIZE_BH
+	//randomly shifting the domain center and rotating the simulation volume
+	REAL rotation_angle;
+	rotation_angle = ((REAL)rand()/(REAL)RAND_MAX)*2.0*pi; //random rotation angle between 0 and 2*pi
+	random_shift[0] = ((REAL)rand()/(REAL)RAND_MAX-0.5)*2*Max_radius; //shift in the x direction between -Rsim and Rsim
+	random_shift[1] = ((REAL)rand()/(REAL)RAND_MAX-0.5)*2*Max_radius; //shift in the y direction between -Rsim and Rsim
+	random_shift[2] = ((REAL)rand()/(REAL)RAND_MAX-0.5)*L; //shift in the z direction between -0.5*Lz and 0.5*Lz
+	printf("MPI task %i: Octree force calculation started with random shift vector (%.3f %.3f %.3f)\n\t    and rotation angle %.3f RAD around the z axis.\n", rank, random_shift[0], random_shift[1], random_shift[2], rotation_angle);
+	//First, we rotate the particles around the z axis by the random angle
+	rotate_vectors_2d(x, rotation_angle, 0, N-1);
+	if (4*Max_radius < L)
+	{
+		//if the maximum diameter is smaller than half of the box size, we use the periodicity length as the root node size
+		RootNodeSize = L;
+	}
+	else
+	{
+		//if the maximum diameter is larger than half of the box size, we use the double of maximum diameter as the root node size
+		RootNodeSize = 4.0*Max_radius; // 2+epsilon times of the maximal diameter
+	}
+	#else
+	random_shift[0] = 0.0; //no shift in the x direction
+	random_shift[1] = 0.0; //no shift in the y direction
+	random_shift[2] = 0.0; //no shift in the z direction
+	if(2*Max_radius < L)
+	{
+		//if the maximum diameter is smaller than half of the box size, we use the periodicity length as the root node size
+		RootNodeSize = L;
+	}
+	else
+	{
+		//if the maximum diameter is larger than half of the box size, we use the double of maximum diameter as the root node size
+		RootNodeSize = 2.0*Max_radius; // 2+epsilon times of the maximal diameter
+	}
+	#endif
+	if(rank==0)
+		printf("\t    Root node size: %.6g Mpc.\n", RootNodeSize);
+	OctreeNode *rootnode = create_node(random_shift[0], random_shift[1], 0.50*RootNodeSize, RootNodeSize); //center of the simulation box, size 2*(Rsim+epsilon)
+	for (int i = 0; i < N; i++)
+    {
+		#ifdef RANDOMIZE_BH
+		//Shifting the particles by the random magnitude with periodic boundary conditions only in the z direction
+		x[3*i+2] += random_shift[2];
+		//Checking the periodic boundaries along the z axis
+		if(x[3*i+2]<0)
+		{
+			x[3*i+2] = x[3*i+2] + L;
+		}
+		else if(x[3*i+2]>=L)
+		{
+			x[3*i+2] = x[3*i+2] - L;
+		}
+		#endif
+        // Insert particles into the octree
+        insert_particle(rootnode, x, M, i);
+	}
+    for(i=0; i<N_mpi_thread; i++)
+    {
+		for(k=0; k<3; k++)
+		{
+			F[3*i+k] = 0;
+		}
+    }
+    chunk = (ID_max-ID_min)/(omp_get_max_threads())/8;
+    if(chunk < 1)
+    {
+        chunk = 1;
+    }
+    if(IS_PERIODIC>=2) 
+	{
+		EwaldCut = ewald_cut*L; // Ewald cutoff radius
+        #pragma omp parallel default(shared)  private(i, m, Fx_tmp, Fy_tmp, Fz_tmp)
+		#pragma omp for schedule(dynamic,chunk)
+			for(i=ID_min; i<ID_max+1; i++)
+			{
+				//using multiple images
+				for(m=-ewald_max; m<ewald_max+1; m++)
+				{
+					Fx_tmp = Fy_tmp = Fz_tmp = 0.0;
+					compute_BH_force_z(rootnode, x, i, SOFT_LENGTH, x[3*i], x[3*i+1], x[3*i+2]+((REAL) m)*L, EwaldCut, &Fx_tmp, &Fy_tmp, &Fz_tmp);
+					#pragma omp atomic
+						F[3*(i-ID_min)] += Fx_tmp;
+					#pragma omp atomic
+						F[3*(i-ID_min)+1] += Fy_tmp;
+					#pragma omp atomic
+						F[3*(i-ID_min)+2] += Fz_tmp;
+				}
+				//adding the external force from the outside of the simulation volume,
+				//if we run a not fully periodic comoving cosmological simulation
+				if(COSMOLOGY == 1 && COMOVING_INTEGRATION == 1)
+				{
+					r_xy = sqrt(pow(x[3*i], 2) + pow(x[3*i+1], 2));
+					cylindrical_force_correction = get_cylindrical_force_correction(r_xy, Rsim, RADIAL_FORCE_TABLE, RADIAL_FORCE_TABLE_SIZE, 1);
+					F[3*(i-ID_min)] += mass_in_unit_sphere * x[3*i] * cylindrical_force_correction;
+					F[3*(i-ID_min)+1] += mass_in_unit_sphere * x[3*i+1] * cylindrical_force_correction;
+				}
+				else if(COSMOLOGY == 1 && COMOVING_INTEGRATION == 0)
+				{
+					F[3*(i-ID_min)] +=  DE * x[3*i];
+					F[3*(i-ID_min)+1] += DE * x[3*i+1];
+				} //non-comoving integration is not implemented for periodic_z (yet?)
+			}
+    }
+    else
+	{
+        #pragma omp parallel default(shared)  private(i, m, Fx_tmp, Fy_tmp, Fz_tmp)
+		#pragma omp for schedule(dynamic,chunk)
+			for(i=ID_min; i<ID_max+1; i++)
+			{
+				Fx_tmp = Fy_tmp = Fz_tmp = 0.0;
+				//using the nearest image in the z direction
+				compute_BH_QP_force_z(rootnode, x, i, SOFT_LENGTH, L, &Fx_tmp, &Fy_tmp, &Fz_tmp);
+				#pragma omp atomic
+					F[3*(i-ID_min)] += Fx_tmp;
+				#pragma omp atomic
+					F[3*(i-ID_min)+1] += Fy_tmp;
+				#pragma omp atomic
+					F[3*(i-ID_min)+2] += Fz_tmp;
+				#ifdef RANDOMIZE_BH
+				//Shifting back the simulation volume to the center, before we calculate the radial forces
+				for(k=0; k<2; k++)
+				{
+					x[3*i+k] -= random_shift[k];
+				}
+				//the z direction is transformed back outside of this loop (from x_tmp array)
+				#endif
+				//adding the external force from the outside of the simulation volume,
+				//if we run a not fully periodic comoving cosmological simulation
+				if(COSMOLOGY == 1 && COMOVING_INTEGRATION == 1)
+				{
+					r_xy = sqrt(pow(x[3*i], 2) + pow(x[3*i+1], 2));
+					cylindrical_force_correction = get_cylindrical_force_correction(r_xy, Rsim, RADIAL_FORCE_TABLE, RADIAL_FORCE_TABLE_SIZE, 1);
+					F[3*(i-ID_min)] += mass_in_unit_sphere * x[3*i] * cylindrical_force_correction;
+					F[3*(i-ID_min)+1] += mass_in_unit_sphere * x[3*i+1] * cylindrical_force_correction;
+				}
+				else if(COSMOLOGY == 1 && COMOVING_INTEGRATION == 0)
+				{
+					F[3*(i-ID_min)] +=  DE * x[3*i];
+					F[3*(i-ID_min)+1] += DE * x[3*i+1];
+				} //non-comoving integration is not implemented for periodic_z (yet?)
+			}
+    }
+	free_node(rootnode);
+	#ifdef RANDOMIZE_BH
+	for (int i = 0; i < N; i++)
+	{
+		x[3*i+2] -= random_shift[2]; //shifting back to the original position with periodic boundary conditions
+		//Checking the periodic boundaries along the z axis
+		if(x[3*i+2]<0)
+		{
+			x[3*i+2] = x[3*i+2] + L;
+		}
+		else if(x[3*i+2]>=L)
+		{
+			x[3*i+2] = x[3*i+2] - L;
+		}
+    }
+	//rotating back the the simulation volume to its original orientation
+	rotate_vectors_2d(x, -rotation_angle, 0, N-1);
+	rotate_vectors_2d(F, -rotation_angle, ID_min, ID_max);
+	#endif
+    //timing
+    double omp_end_time = omp_get_wtime();
+    //timing
+    printf("Octree force calculation finished on MPI task %i. Force calculation wall-clock time = %fs.\n", rank, omp_end_time-omp_start_time);
+    return;
+}
+
+#else
+//Direct force calculation with multiple images only in the z direction
 void forces_periodic_z(REAL* x, REAL* F, int ID_min, int ID_max)
 {
     //timing
@@ -501,4 +1347,5 @@ void forces_periodic_z(REAL* x, REAL* F, int ID_min, int ID_max)
     printf("Force calculation finished on MPI task %i. Force calculation wall-clock time = %fs.\n", rank, omp_end_time-omp_start_time);
     return;
 }
+#endif
 #endif

--- a/StePS/src/global_variables.h
+++ b/StePS/src/global_variables.h
@@ -29,7 +29,11 @@ typedef float REAL;
 typedef double REAL;
 #endif
 
-extern int IS_PERIODIC; //periodic boundary conditions, 0=none, 1=nearest images, 2=ewald forces
+#ifdef USE_BH
+extern REAL THETA;//default value for the opening angle (used in BH forces)
+#endif
+
+extern int IS_PERIODIC; //periodic boundary conditions, 0=none, 1=nearest images, 2=ewald forces, 3>=ewald forces with increased cut-off radius
 extern int COSMOLOGY; //Cosmological Simulation, 0=no, 1=yes
 extern int COMOVING_INTEGRATION; //Comoving integration 0=no, 1=yes, used only when  COSMOLOGY=1
 extern REAL L; //Size of the simulation box

--- a/StePS/src/inputoutput.cc
+++ b/StePS/src/inputoutput.cc
@@ -1379,6 +1379,7 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	hsize_t adim[1] = { 6 };
 	hid_t hdf5_dataspace, hdf5_attribute;
 
+	//NumPart_ThisFile
 	hdf5_dataspace = H5Screate(H5S_SIMPLE);
 	H5Sset_extent_simple(hdf5_dataspace, 1, adim, NULL);
 	hdf5_attribute = H5Acreate(handle, "NumPart_ThisFile", H5T_NATIVE_INT, hdf5_dataspace, H5P_DEFAULT,  H5P_DEFAULT);
@@ -1390,6 +1391,7 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//NumPart_Total
 	hdf5_dataspace = H5Screate(H5S_SIMPLE);
 	H5Sset_extent_simple(hdf5_dataspace, 1, adim, NULL);
 	hdf5_attribute = H5Acreate(handle, "NumPart_Total", H5T_NATIVE_UINT, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
@@ -1397,6 +1399,7 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//NumPart_Total_HighWord
 	hdf5_dataspace = H5Screate(H5S_SIMPLE);
 	H5Sset_extent_simple(hdf5_dataspace, 1, adim, NULL);
 	for(i=0; i<6; i++)
@@ -1406,7 +1409,7 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
-
+	//MassTable
 	hdf5_dataspace = H5Screate(H5S_SIMPLE);
 	H5Sset_extent_simple(hdf5_dataspace, 1, adim, NULL);
 	double mass[6];
@@ -1418,6 +1421,7 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//Time (or scale factor)
 	hdf5_dataspace = H5Screate(H5S_SCALAR);
 	hdf5_attribute = H5Acreate(handle, "Time", H5T_NATIVE_DOUBLE, hdf5_dataspace, H5P_DEFAULT,  H5P_DEFAULT);
 	if(COSMOLOGY == 0 || (OUTPUT_TIME_VARIABLE==0 && COMOVING_INTEGRATION==0))
@@ -1428,6 +1432,7 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//Redshift
 	hdf5_dataspace = H5Screate(H5S_SCALAR);
 	hdf5_attribute = H5Acreate(handle, "Redshift", H5T_NATIVE_DOUBLE, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
 	double redshift=(1.0/a-1.0);
@@ -1435,6 +1440,7 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//BoxSize
 	hdf5_dataspace = H5Screate(H5S_SCALAR);
 	hdf5_attribute = H5Acreate(handle, "BoxSize", H5T_NATIVE_DOUBLE, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
 	if(H0_INDEPENDENT_UNITS == 0)
@@ -1449,6 +1455,7 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//NumFilesPerSnapshot
 	hdf5_dataspace = H5Screate(H5S_SCALAR);
 	hdf5_attribute = H5Acreate(handle, "NumFilesPerSnapshot", H5T_NATIVE_INT, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
 	int numfiles = 1;
@@ -1456,18 +1463,21 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//Omega0 (Omega_matter)
 	hdf5_dataspace = H5Screate(H5S_SCALAR);
 	hdf5_attribute = H5Acreate(handle, "Omega0", H5T_NATIVE_DOUBLE, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
 	H5Awrite(hdf5_attribute, H5T_NATIVE_DOUBLE, &Omega_m);
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//OmegaLambda (Omega_dark_energy)
 	hdf5_dataspace = H5Screate(H5S_SCALAR);
 	hdf5_attribute = H5Acreate(handle, "OmegaLambda", H5T_NATIVE_DOUBLE, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
 	H5Awrite(hdf5_attribute, H5T_NATIVE_DOUBLE, &Omega_lambda);
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//HubbleParam (H0 in 100km/s/Mpc units)
 	hdf5_dataspace = H5Screate(H5S_SCALAR);
 	hdf5_attribute = H5Acreate(handle, "HubbleParam", H5T_NATIVE_DOUBLE, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
 	redshift = H0*UNIT_V/100.0;
@@ -1475,6 +1485,24 @@ void write_header_attributes_in_hdf5(hid_t handle)
 	H5Aclose(hdf5_attribute);
 	H5Sclose(hdf5_dataspace);
 
+	//Parameters of cosmological models beyond LCDM (if applicable)
+	#if COSMOPARAM==1 || COSMOPARAM==2
+	hdf5_dataspace = H5Screate(H5S_SCALAR);
+	hdf5_attribute = H5Acreate(handle, "DE_w0", H5T_NATIVE_DOUBLE, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
+	H5Awrite(hdf5_attribute, H5T_NATIVE_DOUBLE, &w0);
+	H5Aclose(hdf5_attribute);
+	H5Sclose(hdf5_dataspace);
+	#endif
+
+	#if COSMOPARAM==2
+	hdf5_dataspace = H5Screate(H5S_SCALAR);
+	hdf5_attribute = H5Acreate(handle, "DE_wa", H5T_NATIVE_DOUBLE, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
+	H5Awrite(hdf5_attribute, H5T_NATIVE_DOUBLE, &wa);
+	H5Aclose(hdf5_attribute);
+	H5Sclose(hdf5_dataspace);
+	#endif
+
+	//Flags for GADGET compatibility
 	hdf5_dataspace = H5Screate(H5S_SCALAR);
 	hdf5_attribute = H5Acreate(handle, "Flag_Sfr", H5T_NATIVE_INT, hdf5_dataspace, H5P_DEFAULT, H5P_DEFAULT);
 	int zero = 0;


### PR DESCRIPTION
* Added octree force calculation in 3D StePS mode (CPU only)
* Added Periodic BH force calculation (CPU only)
* Added Cylindrical BH force calculation (CPU only)
* Fixed high-accuracy Ewald summation option on CPU mode.
* Better OMP balance in BH force calculation.
* Added RANDOMIZE_BH compile-time option for randomizing the domain center in Octree force calculation.
* Implemented random rotation of the Octree in non-periodic and cylindric boundary  conditions.
* Barnes-Hut opening angle can be set in the Makefile.
* Updated CHANGELOG, README, version, and Makefile templates.
